### PR TITLE
fix(tapctl): authenticate GitHub API requests to avoid rate limiting

### DIFF
--- a/bin/tapctl.py
+++ b/bin/tapctl.py
@@ -228,7 +228,11 @@ def render(template, **env):
 def get(url):
     """Get the content of the URL."""
     logging.debug("GET %s", CYAN(url))
-    return urllib.request.urlopen(url)
+    token = os.environ.get("HOMEBREW_GITHUB_API_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    req = urllib.request.Request(url)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    return urllib.request.urlopen(req)
 
 
 def prompt():


### PR DESCRIPTION
Unauthenticated requests to the GitHub API are capped at 60 per hour per IP, which GitHub Actions runners easily exhaust across parallel jobs. Pass `HOMEBREW_GITHUB_API_TOKEN` or `GITHUB_TOKEN` when available so requests use the authenticated limit of 5000 per hour.