### PR TITLE
fix(ci): install Go before running tapctl.py in auto-update workflow

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -75,6 +75,10 @@ jobs:
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: ${{ runner.os }}-rubygems-
 
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
       - name: Clean Homebrew core data
         run: |
           brew update
@@ -120,6 +124,10 @@ jobs:
 
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: Homebrew/actions/git-user-config@master
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
 
       - name: Download all bottles
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The tapctl.py script uses `go run` to render formula templates via `bitnami/render-template`. Go is not pre-installed on GitHub Actions runners, so both the build and integrate jobs now set it up with `actions/setup-go`.